### PR TITLE
Feat cam manager

### DIFF
--- a/src/BUMP_camManager.mcr
+++ b/src/BUMP_camManager.mcr
@@ -544,7 +544,7 @@ macroScript BUMP_CamMngr
 				/* ENABLING MOVE BUTTONS */
 				fn lst_views_arange_buttons_enablig = (
 					index = lst_views.selection
-					if lst_views.items.count <= 1 then (
+					if lst_views.selection == 0 or lst_views.items.count <= 1 then (
 						btn_up.enabled = false
 						btn_down.enabled = false
 					) else if index == 1 then (
@@ -557,9 +557,18 @@ macroScript BUMP_CamMngr
 						btn_up.enabled = true
 						btn_down.enabled = true
 					)
-					local the_view = batchRenderMgr.GetView index
-					--btn_togleEnabled.state = the_view.enabled
-					btn_togleEnabled.caption = if the_view.enabled then "✅" else "☑️"
+					if index > 0 then (
+						local the_view = batchRenderMgr.GetView index
+						btn_togleEnabled.enabled = true
+						btn_rem.enabled = true
+						btn_togleEnabled.caption = if the_view.enabled then "✅" else "☑️"
+						btn_rem.caption = "❌"
+					) else (
+						btn_togleEnabled.enabled = false
+						btn_rem.enabled = false
+						btn_togleEnabled.caption = "✓"
+						btn_rem.caption = "x"
+					)
 				)
 				
 				/* LIST BATCH VIEWS */

--- a/src/BUMP_camManager.mcr
+++ b/src/BUMP_camManager.mcr
@@ -471,11 +471,9 @@ macroScript BUMP_CamMngr
 				on p10 pressed do preset ratios[10]	
 
 				on roll_Cams rolledUp state do (
-					if state == true do (
-						for i in 1 to CamFloater.rollouts.count do (
-							if CamFloater.rollouts[i] != roll_Cams do (
-								CamFloater.rollouts[i].open = false
-							)
+					for i in 1 to CamFloater.rollouts.count do (
+						if CamFloater.rollouts[i] != roll_Cams do (
+							CamFloater.rollouts[i].open = not state
 						)
 					)
 					resizeFloater()
@@ -494,21 +492,33 @@ macroScript BUMP_CamMngr
 				local owner = if owner != undefined then owner
 				--------------------------------
 				listbox lst_views "Batch Views" height:20  offset:[-10,0]
-				button btn_togleEnabled "☑️" width:24 height:25 tooltip:"Toggle enabled" offset:[108,-272]
-				button btn_up "↑" height:55 tooltip:"Move view up" offset:[108,45]
-				button btn_down "↓"  height:55 tooltip:"Move view down" offset:[108,0]
-				button btn_rem "❌" width:24 height:25 offset:[108,48]
-
-				edittext txt_1 "View name" fieldWidth:(roll_w - 25) bold:true labelOnTop:true  
-				edittext txt_3 "File name" fieldWidth:(roll_w - 25) labelOnTop:true
-				edittext txt_2 "Output" fieldWidth:(roll_w - 60) labelOnTop:true across:2
-				button btn_p "..." align:#right offset:[10,15] tooltip:"Change path"
-				checkbox chk_1 "Override output size in view" align:#left \
-										tooltip:"Set active render output size as view override"
-				button btn_v "Add View to batch" width:(roll_w - 70) height:25 align:#left
-
-				button btn_bup "Refresh" width:(roll_w - 70) height:25 align:#left
-				tooltip:"Update the views list"
+				
+				button btn_togleEnabled "☑️" align:#right width:24 height:25 tooltip:"Toggle enabled" offset:[14,-272]
+				button btn_up "↑" height:55 align:#right tooltip:"Move view up" offset:[14,37]
+				button btn_add_sep "—" width:24 align:#right tooltip:"Add separator" offset:[14,0]
+				button btn_down "↓"  height:55 align:#right tooltip:"Move view down" offset:[14,0]
+				button btn_dup "📋" width:24 height:25 align:#right offset:[14,0] tooltip:"Duplicate view" 
+				button btn_rem "❌" width:24 height:25 align:#right offset:[14,0]
+				
+				button btn_refresh "🔄️ Refresh" height:25 width:(roll_w - 40) align:#left offset:[-10,0] tooltip:"Update the views list" 
+				
+				checkbutton btn_net_render "🕸️ Net" width:50 height:25 align:#left offset:[-10,0]
+				button btn_render "🫖 Render" height:25 width:(roll_w - 90) align:#left offset:[40,-30]
+				
+				
+				group "Edit batch view" (
+					edittext txt_1 "View name" fieldWidth:(roll_w - 35) bold:true labelOnTop:true 
+					label lbl_res "Resolution"
+					edittext txt_2 "Output path" fieldWidth:(roll_w - 80) labelOnTop:true offset:[0,-18]
+					button btn_open_in_explorer "📂" align:#right width:40 offset:[5,-25]
+					edittext txt_3 "File name" fieldWidth:(roll_w - 80) labelOnTop:true
+					button btn_p "..." align:#right width:40 offset:[5,-25] tooltip:"Change path"
+					
+					checkbox chk_1 "Override output size in view" align:#left \
+											tooltip:"Set active render output size as view override"
+					dropdownlist drdwn_state "Scene State" items:#("---------------------")
+				)
+				button btn_v "➕ Add View to batch" width:(roll_w - 70) height:25 align:#left --offset:[0,13]
 				button btn_b "Open Batch window" width:(roll_w - 70) height:25 align:#left
 				--------------------------------
 				local batch_view
@@ -567,7 +577,7 @@ macroScript BUMP_CamMngr
 						btn_togleEnabled.enabled = false
 						btn_rem.enabled = false
 						btn_togleEnabled.caption = "✓"
-						btn_rem.caption = "x"
+						btn_rem.caption = "X"
 					)
 				)
 				
@@ -578,11 +588,21 @@ macroScript BUMP_CamMngr
 					local num = batchRenderMgr.numViews
 					local col = for i=1 to num collect (
 						local the_view = gv i
-						local st = if the_view.enabled then "[v] " else "[ ] "
-						st+the_view.name
+						local st
+						if substring the_view.name 1 5 == "-----" then (
+							st = ""
+						) else (
+							st = if the_view.enabled then "[v] " else "[ ] "
+						)
+						st + the_view.name
 					)
 					lst_views.items = col
 					lst_views_arange_buttons_enablig()
+										
+					states_names = for i in 1 to sceneStateMgr.getCount() collect (sceneStateMgr.GetSceneState i)
+					drdwn_state.items = #("---------------------") + states_names
+					
+					btn_net_render.checked = batchRenderMgr.netRender
 				)
 				
 				/* LOAD VIEW PROPS */
@@ -590,28 +610,42 @@ macroScript BUMP_CamMngr
 				(
 					local the_view = try (batchRenderMgr.GetView index) catch undefined
 					if the_view != undefined then (
+						disableSceneRedraw()
 						txt_1.text = the_view.name
 						local cam  = the_view.camera
 						if isValidNode cam then (
 							owner.roll_Cams.setActiveCam cam
 							-- SET CAM IN LIST
 							findItemInList cam.name owner.roll_Cams.lst_cams
-							-- Get the view Path
-							if the_view.outputFilename != undefined then (
-								txt_2.text = getFilenamePath the_view.outputFilename
-								txt_3.text = filenameFromPath the_view.outputFilename
-							)
-							-- restore scene state
+						)
+						-- Get the view Path
+						if the_view.outputFilename != "" then (
+							txt_2.text = getFilenamePath the_view.outputFilename
+							txt_3.text = filenameFromPath the_view.outputFilename
+						) else (
+							txt_2.text = ""
+							txt_3.text = ""
+						)
+						-- restore scene state
+						local i = finditem drdwn_state.items the_view.sceneStateName
+						drdwn_state.selection = if i == 0 then 1 else i
+						if the_view.sceneStateName != "" do (
 							local ssp = sceneStateMgr.GetParts the_view.sceneStateName
 							sceneStateMgr.Restore the_view.sceneStateName ssp
 						)
 						-- SET RENDER OUTPUT TO THE VIEW OVERRIDE, USEFUL TO SEE THE CROP FRAME ETC...
 						if the_view.overridePreset then (
+							chk_1.checked = true
 							renderWidth  = the_view.width
 							renderHeight = the_view.height
+							lbl_res.caption = renderWidth as string + " x " + renderHeight as string
 							owner.roll_Cams.get_output_values()
+						) else (
+							lbl_res.caption = "Default"
+							chk_1.checked = false
 						)
-						CompleteRedraw()
+						
+						enableSceneRedraw()
 					)
 					the_view
 				)
@@ -619,9 +653,9 @@ macroScript BUMP_CamMngr
 				/* LOAD VIEW PROPS */
 				fn view_settings = (
 					local temp_cam = owner.roll_Cams.active_cam
-					if (temp_cam != undefined) then (
+					if temp_cam != undefined then (
 						txt_1.text = temp_cam.name + "-" + (rendImageAspectRatio as string)
-						if (view_path != undefined) then (
+						if view_path != undefined then (
 							local root     = getFilenamePath view_path
 							local type     = getFilenameType view_path
 							local filename = filenameFromPath view_path
@@ -643,9 +677,25 @@ macroScript BUMP_CamMngr
 					)
 				)
 				
+				/* CLOSE BATHCH WINDOW */
+				fn close_batch_window = (
+					-- https://help.autodesk.com/view/MAXDEV/2026/ENU/?guid=GUID-282F32AC-5A80-4FDB-B8C0-275D2CC15845
+					local batch_window = windows.getChildHWND 0 "Batch Render" parent:#max
+					
+					if batch_window != undefined \
+					and batch_window[4] == "#32770" \ -- window class (filter other windows named "Batch Render")
+					do (
+						windows.sendMessage batch_window[1] 0x0010 0 0  -- 0x0010 = WM_CLOSE
+						return true
+					)
+					
+					return false
+				)
+				
 				/* ADD VIEW */
 				fn view_add =
 				(
+					close_batch_window()
 					local temp_cam = owner.roll_Cams.active_cam
 					if temp_cam != undefined then (
 						if (batchRenderMgr.FindView txt_1.text) == 0 then (
@@ -661,9 +711,94 @@ macroScript BUMP_CamMngr
 					)
 				)
 				
+				/* UPDATE VIEW FILE PATHS */
+				fn view_update =
+				(
+					if lst_views.selection != 0 do (
+						local bv = batchRenderMgr.GetView lst_views.selection
+						local any_changed = false
+						
+						-- Change the name
+						if bv.name != txt_1.text then (
+							if batchRenderMgr.FindView txt_1.text do (
+								messageBox "View Already exist.\nChange name AND try again."
+								return undefined
+							)
+							bv.name = txt_1.text
+							list_views()
+							any_changed = true
+						)
+						
+						-- Change path
+						if txt_2.text == "" or txt_3.text == "" then (
+							view_path = undefined
+							bv.outputFilename = undefined
+							txt_2.text = ""
+							txt_3.text = ""
+							any_changed = true
+						) else if doesfileexist txt_2.text then (
+							view_path = txt_2.text + txt_3.text
+							bv.outputFilename = view_path
+							any_changed = true
+						) else (
+							messageBox "Directory doesn't exists" title:"Error"
+							return undefined
+						)
+						
+						-- Change resolution
+						bv.overridePreset = chk_1.state
+						if chk_1.state do (
+							bv.width  = renderWidth
+							bv.height = renderHeight
+							any_changed = true
+						)
+						
+						-- Change Scene State
+						local selected_scene_state = if drdwn_state.selection > 1 then (
+							drdwn_state.items[drdwn_state.selection]) else ("")
+						
+						if selected_scene_state != bv.sceneStateName do (
+							bv.sceneStateName = selected_scene_state
+							any_changed = true
+						)
+						
+						if any_changed do close_batch_window()
+					)
+				)
+							
+				on txt_1 entered txt do view_update()
+				on txt_2 entered txt do view_update()
+				on txt_3 entered txt do view_update()
+				
+				on chk_1 changed state do (
+					if not state do lbl_res.caption = "Default"
+					view_update()
+				)
+				
+				on drdwn_state selected index do view_update()
+				
+				on btn_open_in_explorer pressed do (
+					if txt_2.text != "" then (
+						if doesfileexist txt_2.text then (
+							ShellLaunch "explorer.exe" ("\"" + txt_2.text + "\"")
+						) else messageBox "Directory doesn't exists" title:"Error"
+					)
+				)
+				
+				on btn_render pressed do (
+					batchRenderMgr.render()
+				)
+				
+				on btn_net_render changed state do (
+					close_batch_window()
+					batchRenderMgr.netRender = state
+				)
+				
 				/* MOVE VIEW UP/DOWN IN BATCH LIST */
 				fn move_view_index from_idx to_idx = (
+					close_batch_window()
 					if from_idx == to_idx or from_idx < 1 or to_idx < 1 then return false
+					
 					local num = batchRenderMgr.numViews
 					if from_idx > num or to_idx > num then return false
 						
@@ -710,12 +845,12 @@ macroScript BUMP_CamMngr
 				--------------------------------
 				on roll_batch open do
 				(
-					view_settings()
 					list_views()
+					lst_views.selection = 0
 				)
 				
 				on roll_batch rolledUp state do (
-					if state == true do (
+					if state do (
 						for i in 1 to CamFloater.rollouts.count do (
 							if CamFloater.rollouts[i] != roll_batch do (
 								CamFloater.rollouts[i].open = false
@@ -735,7 +870,13 @@ macroScript BUMP_CamMngr
 				/* SET VIEW OUTPUT */
 				on btn_p pressed do
 				(
-					if (view_path = getBitmapSaveFileName()) != undefined then (
+					if view_path != undefined then (
+						new_path = getBitmapSaveFileName filename:view_path
+					) else (
+						new_path = getBitmapSaveFileName()
+					)
+					if new_path != undefined then (
+						view_path = new_path
 						update_Path()
 						if active_view != undefined then (
 							SetViewPath active_view
@@ -755,15 +896,27 @@ macroScript BUMP_CamMngr
 							-- refresh list
 							batch_view  = undefined
 							view_name   = ""
-							--	view_path   = undefined
 							active_view = undefined
+							lst_views.selection = 0
 							list_views()
 						)
 					)
 				)
 				
+				/* DUPLICATE VIEW */
+				on btn_dup pressed do (
+					if lst_views.selection != 0 then (
+						batchRenderMgr.DuplicateView lst_views.selection
+						-- Reorder
+						move_view_index batchRenderMgr.numViews (lst_views.selection + 1)
+						lst_views.selection += 1
+						-- refresh list
+						list_views()
+					)
+				)
+				
 				/* UPDATE BATCH VIEWS LIST */
-				on btn_bup pressed do
+				on btn_refresh pressed do
 				(
 					batch_view  = undefined
 					view_name   = ""
@@ -773,13 +926,18 @@ macroScript BUMP_CamMngr
 				)
 				
 				/* OPEN RENDER BATCH */
-				on btn_b pressed do (actionMan.executeAction -43434444 "4096")
+				on btn_b pressed do (
+					actionMan.executeAction -43434444 "4096"
+				)
 				
 				/* TOGGLE ENABLED */
 				on btn_togleEnabled pressed do (
 					local v = batchRenderMgr.GetView lst_views.selection
-					v.enabled = not v.enabled
-					list_views()
+					if substring v.name 1 5 != "-----" then (
+						close_batch_window()
+						v.enabled = not v.enabled
+						list_views()
+					)
 				)
 				
 				/* MOVE VIEW UP */
@@ -796,7 +954,34 @@ macroScript BUMP_CamMngr
 						)
 					)
 				)
-
+				
+				/* ADD SEPARATOR */
+				on btn_add_sep pressed do (
+					local sep_name
+					local n = 0
+					do (
+						n += 1
+						sep_name = "----- " + n as string + " -----"
+					) while (
+						(batchRenderMgr.FindView sep_name) != 0
+					)
+					
+					local sep_view = batchRenderMgr.CreateView undefined
+					sep_view.name = sep_name
+					sep_view.enabled = false
+					
+					-- Reorder
+					if lst_views.selection > 0 then (
+						move_view_index batchRenderMgr.numViews (lst_views.selection + 1)
+						lst_views.selection += 1
+					) else (
+						lst_views.selection = batchRenderMgr.numViews
+					)
+					
+					list_views()
+					get_view_params lst_views.selection
+				)
+				
 				/* MOVE VIEW DOWN */
 				on btn_down pressed do
 				(

--- a/src/BUMP_camManager.mcr
+++ b/src/BUMP_camManager.mcr
@@ -318,12 +318,22 @@ macroScript BUMP_CamMngr
 					if n != undefined then (
 						local cam = if (isKindOf n string) then ( getNodeByName n) else n
 						
+						-- search old active_cam
+						local store_old_active_cam = viewport.activeViewport
+						for i in 1 to viewport.numViews do (
+							if (viewport.getCamera index:i) == active_cam do (
+								viewport.activeViewport = i
+							)
+						)
+						
 						if isValidNode cam AND (isKindOf cam camera) then (
-							if viewport.CanSetToViewport cam then viewport.SetCamera cam				
+							if viewport.CanSetToViewport cam then viewport.SetCamera cam
+							viewport.activeViewport = store_old_active_cam
 							active_cam = cam
 							-- update
-							change_active()				
+							change_active()
 						)
+						
 					)
 				)
 				--------------------------------
@@ -495,7 +505,7 @@ macroScript BUMP_CamMngr
 				button btn_p "..." align:#right offset:[10,15] tooltip:"Change path"
 				checkbox chk_1 "Override output size in view" align:#left \
 										tooltip:"Set active render output size as view override"
-				button btn_v "Add View to batch" width:(roll_w - 80) height:25 align:#left
+				button btn_v "Add View to batch" width:(roll_w - 70) height:25 align:#left
 
 				button btn_bup "Refresh" width:(roll_w - 70) height:25 align:#left
 				tooltip:"Update the views list"
@@ -531,7 +541,7 @@ macroScript BUMP_CamMngr
 					)
 				)
 				
-				/* MOVE BUTTONS ENABLING */
+				/* ENABLING MOVE BUTTONS */
 				fn lst_views_arange_buttons_enablig = (
 					index = lst_views.selection
 					if lst_views.items.count <= 1 then (

--- a/src/BUMP_camManager.mcr
+++ b/src/BUMP_camManager.mcr
@@ -7,6 +7,12 @@
 * 02-2021
 * 01-2022
 * Added Shutter parameters, reordered parameters, changed presets to common aspect ratios
+* 04-2026
+* feat: Restore scene state for the batch view
+* feat: Arrange batch views by  buttons up and down
+* feat: roll_Cams close event saves its position and size to an INI file.
+* feat: fn compareCamNames to sort camera names alphabetically.
+* feat: Resizes the Floater based on the height of its rollouts.
 * -------------------------------------------------------------------------------------------
 */
 macroScript BUMP_CamMngr
@@ -16,6 +22,13 @@ macroScript BUMP_CamMngr
 	silentErrors: false
 	icon:         #("extratools", 1)
 (
+	-- For holding batc view data
+	struct viewData (
+		name, enabled, overridePreset, startFrame, endFrame,
+		width, height, pixelAspect, outputFilename, 
+		camera, sceneStateName, presetFile
+	)
+	
 	struct camManagerTool
 	(
 		CamFloater,		
@@ -24,6 +37,18 @@ macroScript BUMP_CamMngr
 		roll_Cams,
 		roll_Batch,
 		roll_active,
+		
+		private
+		fn resizeFloater = 
+		(
+			local h=CamFloater.rollouts.count * 30 
+			for i in 1 to CamFloater.rollouts.count do (
+				if CamFloater.rollouts[i].open then h+= CamFloater.rollouts[i].height
+			)
+			local scale_dpi = ((dotNetClass "System.Drawing.Graphics").fromHwnd 0).dpiX / 100
+			CamFloater.size = [CamFloater.size[1], h / scale_dpi]
+		),
+		
 		private
 		/* CAMS ROLLOUT */
 		fn ui_cams =
@@ -33,20 +58,18 @@ macroScript BUMP_CamMngr
 				local roll_w = 250 --roll_Cams.width
 				local owner = if owner != undefined then owner
 				--------------------------------
-				group "Active Camera"
-				(
-					label lbl_cam "" align:#left height:25 offset:[0,5]
-				)
+				label lbl_001 "Active Cam:" align:#left across:2
+				label lbl_cam "" align:#left height:25
 				
 				group "Scene cameras"
 				(
-					listbox lst_cams "" height:8
+					listbox lst_cams "" height:20
 					button btn_prev_cam "<<" width:60 align:#left across:3
 						tooltip:"Previous camera"
 					button btn_s "Select" width:80 align:#center
 						tooltip:"Select active camera"
 					button btn_next_cam ">>" width:60 align:#right
-						tooltip: "Nex camera"
+						tooltip: "Next camera"
 				)
 				
 				button btn_1 "Refresh" height:25 width:(roll_w - 25)
@@ -149,7 +172,7 @@ macroScript BUMP_CamMngr
 				)
 				fn get_camprops cam =
 				(
-					if classOf cam == Physical then
+					if (isvalidnode cam) and classOf cam == Physical then
 					(
 						-- Lens
 						spn_fl.enabled = NOT cam.specify_fov
@@ -176,6 +199,7 @@ macroScript BUMP_CamMngr
 						spn_ev.value = cam.exposure_value
 					)
 				)
+				
 				/* DEPRECATED */
 				fn set_camprops cam =
 				(
@@ -242,15 +266,22 @@ macroScript BUMP_CamMngr
 					if isValidNode n then select n
 				)
 				/* LIST CAMERAS IN SCENE */
+				fn compareCamNames a b = case of (
+					(a.name < b.name): -1
+					(a.name > b.name): 1
+					default: 0
+				)
 				fn listCameras =
 				(
-					for cam in cameras collect #(cam, cam.name)
+					local ls = for cam in cameras where (isKindOf cam camera) and not cam.isHidden collect cam
+					qsort ls compareCamNames
+					ls
 				)
 				/* UPDATE CAMERA LIST */
 				fn relist_cams =
 				(
 					list_cam = listCameras()
-					lst_cams.items = for i in list_cam where (isKindOf i[1] camera) collect i[2]					
+					lst_cams.items = for cam in list_cam collect cam.name
 					-- local only_names = for i in list_cam where (isKindOf i[1] camera) collect i[2]
 					-- local only_cams  = for i in list_cam where (isKindOf i[1] camera) collect i[1]
 					-- lst_cams.items = only_names
@@ -258,7 +289,7 @@ macroScript BUMP_CamMngr
 				/* GET THE ACTIVE CAMERA */
 				fn change_active =
 				(
-					if active_cam == undefined then active_cam = getActiveCamera()			
+					if active_cam == undefined or not (isvalidnode active_cam) then active_cam = getActiveCamera()			
 					--active_cam = getActiveCamera()			
 					if active_cam != undefined then (						
 						-- camera properties
@@ -303,9 +334,19 @@ macroScript BUMP_CamMngr
 					get_output_values()
 					chk_ratio.checked = rendLockImageAspectRatio
 				)
-				on roll_Cams close do updateToolbarButtons()
+				
+				on roll_Cams close do (
+					updateToolbarButtons()
+					-- Save position to INI
+					local iniPath = getmaxinifile()
+					setINISetting iniPath "CamManager" "Position" (CamFloater.pos as string)
+					setINISetting iniPath "CamManager" "WindowsSize" (CamFloater.size as string)
+					if roll_Cams.open then setINISetting iniPath "CamManager" "RolloutOpened" "Cams"
+				)
+				
 				/* SELECT CAMERA */
 				on btn_s pressed do ( selCam active_cam )
+				
 				/* PREVIOUS CAMERA */
 				on btn_prev_cam pressed do
 				(
@@ -315,6 +356,7 @@ macroScript BUMP_CamMngr
 					
 					owner.roll_batch.view_settings()
 				)
+				
 				/* NEXT CAMERA */
 				on btn_next_cam pressed do
 				(
@@ -324,6 +366,7 @@ macroScript BUMP_CamMngr
 					
 					owner.roll_batch.view_settings()
 				)
+				
 				/* CHANGE ACTIVE CAMERA */
 				on lst_cams selected item do
 				(
@@ -332,6 +375,7 @@ macroScript BUMP_CamMngr
 					
 					owner.roll_batch.view_settings()	
 				)
+				
 				/* CAMERA PARAMETERS*/
 				-- Lens
 				on chk_fov changed state do
@@ -415,10 +459,22 @@ macroScript BUMP_CamMngr
 				on p8 pressed do preset	 ratios[8]
 				on p9 pressed do preset	 ratios[9]
 				on p10 pressed do preset ratios[10]	
+
+				on roll_Cams rolledUp state do (
+					if state == true do (
+						for i in 1 to CamFloater.rollouts.count do (
+							if CamFloater.rollouts[i] != roll_Cams do (
+								CamFloater.rollouts[i].open = false
+							)
+						)
+					)
+					resizeFloater()
+				)
 				/*------------------------------ ROLLOUT END ------------------------------*/
 			)
 			roll_Cams
 		),
+		
 		/* BATCH ROLLOUT */
 		fn ui_batch =
 		(
@@ -427,18 +483,20 @@ macroScript BUMP_CamMngr
 				local roll_w = 250
 				local owner = if owner != undefined then owner
 				--------------------------------
-				group "Batch views"
-				(
-					listbox lst_views "Batch Views" height:5
-					edittext txt_1 "View name" fieldWidth:(roll_w - 25) bold:true labelOnTop:true
-					edittext txt_3 "File name" fieldWidth:(roll_w - 25) labelOnTop:true
-					edittext txt_2 "Output" fieldWidth:(roll_w - 60) labelOnTop:true across:2
-					button btn_p "..." align:#right offset:[0,15] tooltip:"Change path"
-					checkbox chk_1 "Override output size in view" align:#left \
-											tooltip:"Set active render output size as view override"
-					button btn_v "Add View to batch" width:(roll_w - 80) height:25 align:#left across:2
-					button btn_rem "Delete" height:25 align:#right
-				)		
+				listbox lst_views "Batch Views" height:20  offset:[-10,0]
+				button btn_togleEnabled "☑️" width:24 height:25 tooltip:"Toggle enabled" offset:[108,-272]
+				button btn_up "↑" height:55 tooltip:"Move view up" offset:[108,45]
+				button btn_down "↓"  height:55 tooltip:"Move view down" offset:[108,0]
+				button btn_rem "❌" width:24 height:25 offset:[108,48]
+
+				edittext txt_1 "View name" fieldWidth:(roll_w - 25) bold:true labelOnTop:true  
+				edittext txt_3 "File name" fieldWidth:(roll_w - 25) labelOnTop:true
+				edittext txt_2 "Output" fieldWidth:(roll_w - 60) labelOnTop:true across:2
+				button btn_p "..." align:#right offset:[10,15] tooltip:"Change path"
+				checkbox chk_1 "Override output size in view" align:#left \
+										tooltip:"Set active render output size as view override"
+				button btn_v "Add View to batch" width:(roll_w - 80) height:25 align:#left
+
 				button btn_bup "Refresh" width:(roll_w - 70) height:25 align:#left
 				tooltip:"Update the views list"
 				button btn_b "Open Batch window" width:(roll_w - 70) height:25 align:#left
@@ -453,12 +511,14 @@ macroScript BUMP_CamMngr
 				(
 					local idx = FindItem lst.Items item
 					if idx != 0 then lst.selection = idx
-				)		
+				)
+				
 				/* SET VIEW OUT PATH */
 				fn SetViewPath the_view =
 				(
 					if view_path != undefined then the_view.outputFilename = view_path
 				)
+				
 				/* UPDATE BITMAP FILENAME */
 				fn update_Path cam: =
 				(
@@ -470,6 +530,28 @@ macroScript BUMP_CamMngr
 						txt_3.text = ""
 					)
 				)
+				
+				/* MOVE BUTTONS ENABLING */
+				fn lst_views_arange_buttons_enablig = (
+					index = lst_views.selection
+					if lst_views.items.count <= 1 then (
+						btn_up.enabled = false
+						btn_down.enabled = false
+					) else if index == 1 then (
+						btn_up.enabled = false
+						btn_down.enabled = true
+					) else if index == lst_views.items.count then (
+						btn_up.enabled = true
+						btn_down.enabled = false
+					) else (
+						btn_up.enabled = true
+						btn_down.enabled = true
+					)
+					local the_view = batchRenderMgr.GetView index
+					--btn_togleEnabled.state = the_view.enabled
+					btn_togleEnabled.caption = if the_view.enabled then "✅" else "☑️"
+				)
+				
 				/* LIST BATCH VIEWS */
 				fn list_views =
 				(
@@ -477,11 +559,13 @@ macroScript BUMP_CamMngr
 					local num = batchRenderMgr.numViews
 					local col = for i=1 to num collect (
 						local the_view = gv i
-						local st = if the_view.enabled then "[x] " else "[o] "
+						local st = if the_view.enabled then "[v] " else "[ ] "
 						st+the_view.name
 					)
 					lst_views.items = col
+					lst_views_arange_buttons_enablig()
 				)
+				
 				/* LOAD VIEW PROPS */
 				fn get_view_params index =
 				(
@@ -498,6 +582,9 @@ macroScript BUMP_CamMngr
 								txt_2.text = getFilenamePath the_view.outputFilename
 								txt_3.text = filenameFromPath the_view.outputFilename
 							)
+							-- restore scene state
+							local ssp = sceneStateMgr.GetParts the_view.sceneStateName
+							sceneStateMgr.Restore the_view.sceneStateName ssp
 						)
 						-- SET RENDER OUTPUT TO THE VIEW OVERRIDE, USEFUL TO SEE THE CROP FRAME ETC...
 						if the_view.overridePreset then (
@@ -509,9 +596,9 @@ macroScript BUMP_CamMngr
 					)
 					the_view
 				)
+				
 				/* LOAD VIEW PROPS */
-				fn view_settings =
-				(
+				fn view_settings = (
 					local temp_cam = owner.roll_Cams.active_cam
 					if (temp_cam != undefined) then (
 						txt_1.text = temp_cam.name + "-" + (rendImageAspectRatio as string)
@@ -522,7 +609,7 @@ macroScript BUMP_CamMngr
 							
 							local comp_filename = temp_cam.name + type
 							for i in owner.roll_Cams.list_cam do (
-								local n = i[2]
+								local n = i.name
 								local f = matchPattern filename pattern:("*"+n+"*")
 								if f then (
 									local filename_parse = findString filename n
@@ -536,6 +623,7 @@ macroScript BUMP_CamMngr
 						update_Path()
 					)
 				)
+				
 				/* ADD VIEW */
 				fn view_add =
 				(
@@ -553,6 +641,53 @@ macroScript BUMP_CamMngr
 						) else messageBox "View Already exist.\nChange name AND try again."
 					)
 				)
+				
+				/* MOVE VIEW UP/DOWN IN BATCH LIST */
+				fn move_view_index from_idx to_idx = (
+					if from_idx == to_idx or from_idx < 1 or to_idx < 1 then return false
+					local num = batchRenderMgr.numViews
+					if from_idx > num or to_idx > num then return false
+						
+					local min_replace_indx = if from_idx > to_idx then to_idx else from_idx
+					
+					-- Collect views data
+					local views_data = for i = min_replace_indx to num collect (
+						local v = batchRenderMgr.GetView i
+						viewData v.name v.enabled v.overridePreset v.startFrame v.endFrame \
+							v.width v.height v.pixelAspect v.outputFilename v.camera \
+							v.sceneStateName v.presetFile
+					)
+					
+					-- Reorder the data array
+					local item = views_data[from_idx - min_replace_indx + 1]
+					deleteItem views_data (from_idx - min_replace_indx + 1)
+					insertItem item views_data (to_idx - min_replace_indx + 1)
+					
+					-- Delete views (from end to avoid index shift)
+					for i = num to min_replace_indx by -1 do batchRenderMgr.DeleteView i
+					
+					-- Recreate views in new order
+					for vd in views_data do (
+						local new_v = batchRenderMgr.CreateView vd.camera
+						if new_v != undefined then
+						(
+							if new_v.name != vd.name do new_v.name = vd.name
+							new_v.enabled = vd.enabled
+							new_v.overridePreset = vd.overridePreset
+							new_v.startFrame = vd.startFrame
+							new_v.endFrame = vd.endFrame
+							new_v.width = vd.width
+							new_v.height = vd.height
+							new_v.pixelAspect = vd.pixelAspect
+							new_v.outputFilename = vd.outputFilename
+							new_v.sceneStateName = vd.sceneStateName
+							new_v.presetFile = vd.presetFile
+						)
+					)
+
+					return true
+				)
+				
 				--------------------------------
 				on roll_batch open do
 				(
@@ -561,15 +696,23 @@ macroScript BUMP_CamMngr
 				)
 				
 				on roll_batch rolledUp state do (
-					if NOT state then (
-						owner.CamFloater.size.y -= roll_batch.height
-					) else (
-						owner.CamFloater.size.y += roll_batch.height
+					if state == true do (
+						for i in 1 to CamFloater.rollouts.count do (
+							if CamFloater.rollouts[i] != roll_batch do (
+								CamFloater.rollouts[i].open = false
+							)
+						)
 					)
+					resizeFloater()
 				)
+				
 				--------------------------------				
 				/* GET BATCH VIEW PARAMS */
-				on lst_views selected item do ( active_view = get_view_params item )
+				on lst_views selected index do (
+					active_view = get_view_params index
+					lst_views_arange_buttons_enablig()
+				)
+				
 				/* SET VIEW OUTPUT */
 				on btn_p pressed do
 				(
@@ -580,8 +723,10 @@ macroScript BUMP_CamMngr
 						)
 					)
 				)
+				
 				/* ADD VIEW */
 				on btn_v pressed do ( view_add() )
+				
 				/* DELETE VIEW */
 				on btn_rem pressed do
 				(
@@ -597,6 +742,7 @@ macroScript BUMP_CamMngr
 						)
 					)
 				)
+				
 				/* UPDATE BATCH VIEWS LIST */
 				on btn_bup pressed do
 				(
@@ -606,12 +752,59 @@ macroScript BUMP_CamMngr
 					active_view = undefined					
 					list_views()
 				)
+				
 				/* OPEN RENDER BATCH */
 				on btn_b pressed do (actionMan.executeAction -43434444 "4096")
+				
+				/* TOGGLE ENABLED */
+				on btn_togleEnabled pressed do (
+					local v = batchRenderMgr.GetView lst_views.selection
+					v.enabled = not v.enabled
+					list_views()
+				)
+				
+				/* MOVE VIEW UP */
+				on btn_up pressed do
+				(
+					if lst_views.selection > 0 and lst_views.selection > 1 then
+					(
+						local sel = lst_views.selection
+						if move_view_index sel (sel - 1) then
+						(
+							lst_views.selection = sel - 1
+							list_views()
+							active_view = batchRenderMgr.GetView (sel - 1)
+						)
+					)
+				)
+
+				/* MOVE VIEW DOWN */
+				on btn_down pressed do
+				(
+					if lst_views.selection > 0 and lst_views.selection < lst_views.items.count then
+					(
+						local sel = lst_views.selection
+						if move_view_index sel (sel + 1) then
+						(
+							lst_views.selection = sel + 1
+							list_views()
+							active_view = batchRenderMgr.GetView (sel + 1)
+						)
+					)
+				)
+				
+				on roll_Batch close do (
+					-- Save position to INI
+					if roll_Batch.open then (
+						local iniPath = getmaxinifile()
+						setINISetting iniPath "CamManager" "RolloutOpened" "Batch"
+					)
+				)
 				/*------------------------------ ROLLOUT END ------------------------------*/
 			)
 			roll_batch
 		),
+		
 		public
 		/* TOOL MAIN UI */
 		fn showUI =
@@ -629,9 +822,22 @@ macroScript BUMP_CamMngr
 					roll_Cams.owner = this
 					roll_Batch.owner = this
 					
-					CamFloater = newRolloutFloater "Camera Manager" 270 663 50 50 lockHeight:true lockWidth:true
-					addRollout roll_Cams  CamFloater border:false
-					addRollout roll_Batch CamFloater
+					-- Restore position from INI
+					local iniPath = getmaxinifile()
+					local posStr = getINISetting iniPath "CamManager" "Position"
+					local sizeStr = getINISetting iniPath "CamManager" "WindowsSize"
+					if posStr != "" and sizeStr != "" then
+					(
+						local p = execute posStr
+						local s = execute sizeStr
+						CamFloater = newRolloutFloater "Camera Manager" s[1] s[2] p[1] p[2] lockHeight:false lockWidth:true
+					) else (
+						CamFloater = newRolloutFloater "Camera Manager" dialog_width 663 50 50 lockHeight:false lockWidth:true
+					)
+					local rolloutOpened = getINISetting iniPath "CamManager" "RolloutOpened"
+					addRollout roll_Cams  CamFloater rolledup:(rolloutOpened != "Cams")
+					addRollout roll_Batch CamFloater rolledUp:(rolloutOpened != "Batch")
+
 					res = true
 				)
 			res


### PR DESCRIPTION
feat: If active view without the camera, it tries to find the view with the previous active camera
feat: Restore scene state for the batch view
feat: arrange batch views by buttons up and down
feat: roll_Cams close event saves its position and size to an INI file.
feat: fn compareCamNames to sort camera names alphabetically.
feat: resizeFloater function: This private function resizes the Floater based on the height of its rollouts.

add: viewData: This structure holds data for batch view settings

UI Adjustments
Listbox lst_views height increased to 20 for better visibility and usability.
Buttons added for moving views up and down in the batch list (btn_up, btn_down), toggling enabled status (btn_togleEnabled).
Enhanced UI elements such as labels, buttons, and checkboxes to ensure better user interaction.

Miscellaneous Improvements
Minor adjustments in event handling functions like on btn_s pressed, etc., to improve functionality based on new data structures and behaviors.

This commit significantly improves the organization and interactivity of the Camera Manager tool, making it more user-friendly and better suited for managing multiple camera settings within a scene.

UPD:
* Some settings have been moved from Batch Render   to roll_batch:
  - Duplicate View
  - Newt Render
  - Render
  - Scene state
* Upon changing batch view settings, they are immediately applied.
(if the Batch Render window is open, it will close because the data in the window does not automatically change)
* You can add a separator (empty batch vew).
* When roll_Cams is rolled up, roll_batch unfolds.